### PR TITLE
Add UI density setting

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom'; // Removed BrowserRouter
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import { BallotProvider } from './hooks/useBallot';
+import { SettingsProvider } from './hooks/useSettings';
 import Header from './components/layout/Header';
 import Navbar from './components/layout/Navbar';
 import HomePage from './pages/HomePage';
@@ -40,6 +41,7 @@ const App: React.FC = () => {
   return (
       <AuthProvider>
         <BallotProvider>
+          <SettingsProvider>
           <div className="min-h-screen flex flex-col">
             <Header />
             {/* Adjusted padding: pt-20 for header (h-16 + p-4), px-4 for horizontal, pb-20 for Navbar */}
@@ -48,6 +50,7 @@ const App: React.FC = () => {
             </main>
             <Navbar />
           </div>
+          </SettingsProvider>
         </BallotProvider>
       </AuthProvider>
   );

--- a/components/candidates/CandidateCard.tsx
+++ b/components/candidates/CandidateCard.tsx
@@ -4,7 +4,8 @@ import { Candidate } from '../../types';
 import { ViewMode } from '../../constants';
 import { getCycleById, getFormattedElectionName, getFormattedCandidateOfficeName } from '../../services/dataService';
 import { BuildingOffice2Icon, CalendarDaysIcon, ArrowRightIcon, CheckBadgeIcon } from '@heroicons/react/24/outline';
-import { useNotes } from '../../hooks/useNotes'; 
+import { useNotes } from '../../hooks/useNotes';
+import { useSettings } from '../../hooks/useSettings';
 
 interface CandidateCardProps {
   candidate: Candidate;
@@ -34,6 +35,7 @@ const CandidateCard: React.FC<CandidateCardProps> = ({ candidate, viewMode, onTo
   const { notes, addNote, getLatestNote } = useNotes(candidate.id);
   const [isQuickNoteVisible, setIsQuickNoteVisible] = useState(false);
   const [quickNoteText, setQuickNoteText] = useState('');
+  const { uiDensity } = useSettings();
 
   const latestNote = getLatestNote();
 
@@ -44,6 +46,7 @@ const CandidateCard: React.FC<CandidateCardProps> = ({ candidate, viewMode, onTo
   const selectedForBallot = electionDate ? isCandidateSelected(candidate.id, electionDate) : false;
 
   const cardBaseClasses = "bg-white shadow-lg rounded-lg overflow-hidden transition-all duration-300 hover:shadow-xl border border-midnight-navy/10";
+  const paddingClasses = uiDensity === 'compact' ? 'p-3 sm:p-4' : 'p-4 sm:p-6';
   
   const incumbentBadge = candidate.isIncumbent ? (
     <span className="ml-2 text-xs font-semibold text-white bg-sunlight-gold px-2 py-0.5 rounded-full inline-flex items-center">
@@ -135,7 +138,7 @@ const CandidateCard: React.FC<CandidateCardProps> = ({ candidate, viewMode, onTo
             onError={(e) => (e.currentTarget.src = 'https://picsum.photos/400/300?grayscale')}
           />
         </Link>
-        <div className="p-4 sm:p-6 flex flex-col flex-grow">
+        <div className={`${paddingClasses} flex flex-col flex-grow`}>
           <div className="flex justify-between items-start">
             <Link to={`/candidate/${candidate.id}`} className="hover:text-sunlight-gold transition-colors flex-grow mr-2">
               <h3 className="text-xl font-display font-semibold text-midnight-navy mb-1">
@@ -180,7 +183,7 @@ const CandidateCard: React.FC<CandidateCardProps> = ({ candidate, viewMode, onTo
   return (
     <div className={`${cardBaseClasses} flex flex-col sm:flex-row items-start sm:items-center`}>
       {/* Image Link removed for LIST view */}
-      <div className="p-4 sm:p-6 flex-grow w-full">
+      <div className={`${paddingClasses} flex-grow w-full`}>
         <div className="flex justify-between items-start mb-1">
           <Link to={`/candidate/${candidate.id}`} className="hover:text-sunlight-gold transition-colors flex-grow mr-2">
             <h3 className="text-xl font-display font-semibold text-midnight-navy">

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type UiDensity = 'normal' | 'compact';
+
+interface SettingsContextType {
+  uiDensity: UiDensity;
+  setUiDensity: (density: UiDensity) => void;
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+const UI_DENSITY_STORAGE_KEY = 'uiDensity';
+
+export const SettingsProvider: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
+  const [uiDensity, setUiDensityState] = useState<UiDensity>('normal');
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(UI_DENSITY_STORAGE_KEY) as UiDensity | null;
+      if (stored === 'compact' || stored === 'normal') {
+        setUiDensityState(stored);
+      }
+    } catch (err) {
+      console.error('Error reading uiDensity from localStorage', err);
+    }
+  }, []);
+
+  const setUiDensity = (density: UiDensity) => {
+    setUiDensityState(density);
+    try {
+      localStorage.setItem(UI_DENSITY_STORAGE_KEY, density);
+    } catch (err) {
+      console.error('Error saving uiDensity to localStorage', err);
+    }
+  };
+
+  return (
+    <SettingsContext.Provider value={{ uiDensity, setUiDensity }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = (): SettingsContextType => {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
+};

--- a/pages/BallotMeasuresListPage.tsx
+++ b/pages/BallotMeasuresListPage.tsx
@@ -9,13 +9,15 @@ import {
   isElectionPast // Use centralized version
 } from '../services/dataService';
 import { DocumentCheckIcon, InformationCircleIcon, CalendarDaysIcon } from '@heroicons/react/24/outline';
-import { useBallot } from '../hooks/useBallot'; 
+import { useBallot } from '../hooks/useBallot';
+import { useSettings } from '../hooks/useSettings';
 
 const BallotMeasuresListPage: React.FC = () => {
   const [allMeasures, setAllMeasures] = useState<BallotMeasure[]>([]);
   const [upcomingElectionEvents, setUpcomingElectionEvents] = useState<Cycle[]>([]);
   const { selectedElectionDate: ballotSelectedElectionDate } = useBallot();
   const [selectedElectionFilter, setSelectedElectionFilter] = useState<string>('');
+  const { uiDensity } = useSettings();
 
   useEffect(() => {
     setAllMeasures(getAllBallotMeasures());
@@ -81,10 +83,10 @@ const BallotMeasuresListPage: React.FC = () => {
         {filteredMeasures.length > 0 ? (
           <div className="space-y-6">
             {filteredMeasures.map(measure => (
-              <Link 
-                key={measure.id} 
-                to={`/ballot-measure/${measure.id}`} 
-                className="block bg-slate-100 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow border border-midnight-navy/20 hover:border-civic-blue"
+              <Link
+                key={measure.id}
+                to={`/ballot-measure/${measure.id}`}
+                className={`block bg-slate-100 ${uiDensity === 'compact' ? 'p-4' : 'p-6'} rounded-lg shadow-md hover:shadow-lg transition-shadow border border-midnight-navy/20 hover:border-civic-blue`}
               >
                 <h2 className="text-xl font-semibold text-midnight-navy mb-1">{measure.title}</h2>
                 <p className="text-sm text-midnight-navy/70 flex items-center">

--- a/pages/ElectionInfoPage.tsx
+++ b/pages/ElectionInfoPage.tsx
@@ -2,12 +2,14 @@ import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { Cycle } from '../types';
 import { CalendarDaysIcon, MapPinIcon, LifebuoyIcon, PencilSquareIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
-import { getAllCycles, getFormattedElectionName } from '../services/dataService'; 
+import { getAllCycles, getFormattedElectionName } from '../services/dataService';
 import { useAllNotesSummary } from '../hooks/useAllNotesSummary';
+import { useSettings } from '../hooks/useSettings';
 
 const ElectionInfoPage: React.FC = () => {
-  const allElectionEvents = useMemo(() => getAllCycles(), []); 
+  const allElectionEvents = useMemo(() => getAllCycles(), []);
   const allNotesSummary = useAllNotesSummary();
+  const { uiDensity, setUiDensity } = useSettings();
 
   const relevantElection: Cycle | null = allElectionEvents.length > 0 ? allElectionEvents[0] : null;
 
@@ -21,6 +23,18 @@ const ElectionInfoPage: React.FC = () => {
     <div className="max-w-4xl mx-auto">
       <div className="bg-white shadow-xl rounded-lg p-6 md:p-10 border border-midnight-navy/10">
         <h1 className="text-3xl font-display font-bold text-midnight-navy mb-8 text-center">Election Information & Q&A</h1>
+        <div className="mb-8 text-right">
+          <label htmlFor="ui-density" className="text-sm mr-2">UI Density:</label>
+          <select
+            id="ui-density"
+            value={uiDensity}
+            onChange={(e) => setUiDensity(e.target.value as 'normal' | 'compact')}
+            className="border border-midnight-navy/20 rounded px-2 py-1 text-sm"
+          >
+            <option value="normal">Normal</option>
+            <option value="compact">Compact</option>
+          </select>
+        </div>
 
         <div className="mb-10 grid grid-cols-1 md:grid-cols-2 gap-6">
             <InfoCard title="Key Election Dates" icon={<CalendarDaysIcon className="h-8 w-8 text-civic-blue" />}>
@@ -104,10 +118,12 @@ interface InfoCardProps {
     children: React.ReactNode;
 }
 const InfoCard: React.FC<InfoCardProps> = ({ title, icon, children }) => {
+    const { uiDensity } = useSettings();
+    const padding = uiDensity === 'compact' ? 'p-4' : 'p-6';
     return (
-        <div className="bg-slate-100 p-6 rounded-lg shadow-md border border-midnight-navy/10">
+        <div className={`bg-slate-100 ${padding} rounded-lg shadow-md border border-midnight-navy/10`}>
             <div className="flex items-center mb-3">
-                {icon} 
+                {icon}
                 <h3 className="text-xl font-display font-semibold text-midnight-navy ml-3">{title}</h3>
             </div>
             <div className="text-midnight-navy/90 text-sm space-y-1 font-sans">


### PR DESCRIPTION
## Summary
- create `useSettings` context with `uiDensity`
- provide settings context in `App`
- adjust `CandidateCard`, `InfoCard`, and ballot measure card for compact padding
- add UI density toggle on the Election Info page

## Testing
- `npx tsc --noEmit` *(fails: cannot find React JSX runtime and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_684245f74a1c8324990e16da4523d2d7