### PR TITLE
Add skeleton loading placeholders and alternating background styling

### DIFF
--- a/components/SkeletonCard.tsx
+++ b/components/SkeletonCard.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const SkeletonCard: React.FC = () => {
+  return (
+    <div className="animate-pulse border border-midnight-navy/10 shadow-lg rounded-lg p-4 space-y-4">
+      <div className="h-48 bg-slate-200 rounded w-full" />
+      <div className="space-y-2">
+        <div className="h-5 bg-slate-200 rounded w-3/4" />
+        <div className="h-4 bg-slate-200 rounded w-1/2" />
+        <div className="h-4 bg-slate-200 rounded w-2/3" />
+      </div>
+    </div>
+  );
+};
+
+export default SkeletonCard;

--- a/components/candidates/CandidateCard.tsx
+++ b/components/candidates/CandidateCard.tsx
@@ -8,9 +8,10 @@ import { useNotes } from '../../hooks/useNotes';
 
 interface CandidateCardProps {
   candidate: Candidate;
-  viewMode: string; 
+  viewMode: string;
   onToggleCandidateBallotStatus: (candidate: Candidate, electionDate: string) => void;
   isCandidateSelected: (candidateId: number, electionDate: string) => boolean;
+  className?: string;
 }
 
 const getPartyAbbreviation = (party: string): string => {
@@ -24,7 +25,7 @@ const getPartyAbbreviation = (party: string): string => {
   return party.charAt(0).toUpperCase(); // Fallback to first letter
 };
 
-const CandidateCard: React.FC<CandidateCardProps> = ({ candidate, viewMode, onToggleCandidateBallotStatus, isCandidateSelected }) => {
+const CandidateCard: React.FC<CandidateCardProps> = ({ candidate, viewMode, onToggleCandidateBallotStatus, isCandidateSelected, className }) => {
   const cycle = getCycleById(candidate.cycleId); 
   const electionDate = cycle?.electionDate; 
   const formattedElectionName = getFormattedElectionName(cycle);
@@ -126,7 +127,7 @@ const CandidateCard: React.FC<CandidateCardProps> = ({ candidate, viewMode, onTo
 
   if (viewMode === ViewMode.GRID) {
     return (
-      <div className={`${cardBaseClasses} flex flex-col`}>
+      <div className={`${cardBaseClasses} flex flex-col ${className ?? ''}`}>
         <Link to={`/candidate/${candidate.id}`} className="block hover:opacity-90 transition-opacity">
           <img 
             src={candidate.photoUrl || `https://picsum.photos/seed/${candidate.slug}/400/300`} 
@@ -178,7 +179,7 @@ const CandidateCard: React.FC<CandidateCardProps> = ({ candidate, viewMode, onTo
   // LIST View
   const partyAbbreviation = getPartyAbbreviation(candidate.party);
   return (
-    <div className={`${cardBaseClasses} flex flex-col sm:flex-row items-start sm:items-center`}>
+    <div className={`${cardBaseClasses} flex flex-col sm:flex-row items-start sm:items-center ${className ?? ''}`}>
       {/* Image Link removed for LIST view */}
       <div className="p-4 sm:p-6 flex-grow w-full">
         <div className="flex justify-between items-start mb-1">

--- a/pages/CandidateProfilePage.tsx
+++ b/pages/CandidateProfilePage.tsx
@@ -10,6 +10,7 @@ import {
   getCandidatesByOfficeAndCycle
 } from '../services/dataService';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
+import SkeletonCard from '../components/SkeletonCard';
 import { ArrowLeftIcon, BuildingOffice2Icon, CalendarDaysIcon, GlobeAltIcon, EnvelopeIcon, PhoneIcon, UserGroupIcon, PlusCircleIcon, MinusCircleIcon, ScaleIcon, CheckBadgeIcon, PencilSquareIcon, ChatBubbleOvalLeftEllipsisIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { useBallot } from '../hooks/useBallot';
 import { useNotes } from '../hooks/useNotes';
@@ -108,7 +109,7 @@ const CandidateProfilePage: React.FC = () => {
     }
   }, [location, loading]); // Depend on loading to ensure ref is available
 
-  if (loading) return <LoadingSpinner size="lg" />;
+  if (loading) return <SkeletonCard />;
   if (!candidate || !candidateCycle) return <div className="text-center py-10 text-sunlight-gold">Candidate or election information not found.</div>;
 
   const surveyQuestions = getSurveyQuestions();
@@ -403,16 +404,16 @@ const CandidateProfilePage: React.FC = () => {
         </h2>
         {opponents.length > 0 ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {opponents.map(op => {
+            {opponents.map((op, idx) => {
               let opponentDisplayName = `${op.firstName} ${op.lastName}`;
               if (op.officeId === 5 && op.runningMateName) {
                 opponentDisplayName += ` / ${op.runningMateName}`;
               }
               return (
-                <Link 
-                  key={op.id} 
-                  to={`/candidate/${op.id}`} 
-                  className="block bg-slate-100 p-4 rounded-lg shadow-md hover:shadow-lg transition-shadow border border-midnight-navy/10 hover:border-sunlight-gold focus:outline-none focus:ring-2 focus:ring-sunlight-gold"
+                <Link
+                  key={op.id}
+                  to={`/candidate/${op.id}`}
+                  className={`block p-4 rounded-lg shadow-md hover:shadow-lg transition-shadow border border-midnight-navy/10 hover:border-sunlight-gold focus:outline-none focus:ring-2 focus:ring-sunlight-gold ${idx % 2 === 1 ? 'bg-slate-50' : 'bg-slate-100'}`}
                 >
                   <div className="flex items-center">
                     <img 

--- a/pages/HomePage.tsx
+++ b/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import CandidateCard from '../components/candidates/CandidateCard';
+import SkeletonCard from '../components/SkeletonCard';
 import FilterControls from '../components/candidates/FilterControls';
 import { Candidate, Cycle } from '../types'; // Removed CandidateSelection
 import { ViewMode } from '../constants'; // Changed import
@@ -21,6 +22,7 @@ const HomePage: React.FC = () => {
 
   const [allCandidatesData, setAllCandidatesData] = useState<Candidate[]>([]);
   const [upcomingElections, setUpcomingElections] = useState<Cycle[]>([]);
+  const [loading, setLoading] = useState(true);
   
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedOffice, setSelectedOffice] = useState(''); 
@@ -29,6 +31,7 @@ const HomePage: React.FC = () => {
   const [viewMode, setViewMode] = useState<string>(ViewMode.GRID); 
 
   useEffect(() => {
+    setLoading(true);
     setAllCandidatesData(getAllCandidates());
     const cycles = getUpcomingCycles();
     setUpcomingElections(cycles);
@@ -44,6 +47,7 @@ const HomePage: React.FC = () => {
       // No upcoming elections, and ballot context is past or null
       setSelectedElectionDateForFilter(''); // This will mean "All Upcoming Elections" (which will be empty)
     }
+    setLoading(false);
   }, [ballotSelectedElectionDate]); // Re-run when ballot context's selected date changes
 
   const handleCandidateBallotAction = (candidate: Candidate, electionDate: string) => {
@@ -80,6 +84,16 @@ const HomePage: React.FC = () => {
     });
   }, [allCandidatesData, searchTerm, selectedOffice, selectedElectionDateForFilter, selectedParty, upcomingElections]);
 
+  if (loading) {
+    return (
+      <div className={`grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`}>
+        {Array.from({ length: 8 }).map((_, index) => (
+          <SkeletonCard key={index} />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div>
       <FilterControls
@@ -98,13 +112,14 @@ const HomePage: React.FC = () => {
 
       {filteredCandidates.length > 0 ? (
         <div className={`grid gap-6 ${viewMode === ViewMode.GRID ? 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4' : 'grid-cols-1'}`}>
-          {filteredCandidates.map(candidate => (
-            <CandidateCard 
-              key={candidate.id} 
-              candidate={candidate} 
+          {filteredCandidates.map((candidate, index) => (
+            <CandidateCard
+              key={candidate.id}
+              candidate={candidate}
               viewMode={viewMode}
-              onToggleCandidateBallotStatus={handleCandidateBallotAction} 
+              onToggleCandidateBallotStatus={handleCandidateBallotAction}
               isCandidateSelected={isCandidateSelectedForCard}
+              className={viewMode === ViewMode.LIST && index % 2 === 1 ? 'bg-slate-50' : ''}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- create `SkeletonCard` component with Tailwind `animate-pulse`
- use `SkeletonCard` while `HomePage` and `CandidateProfilePage` data loads
- support custom class names in `CandidateCard`
- alternate candidate row background colors on lists

## Testing
- `npx tsc --noEmit` *(fails: several existing type errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684245f610908324a9f0a3b0c0a88fa5