### PR TITLE
Add swipeable ballot items and completion confetti

### DIFF
--- a/components/SwipeableBallotItem.tsx
+++ b/components/SwipeableBallotItem.tsx
@@ -1,0 +1,71 @@
+import React, { useState, useRef } from 'react';
+import { TrashIcon } from '@heroicons/react/24/outline';
+
+interface SwipeableBallotItemProps {
+  onRemove: () => void;
+  children: React.ReactNode;
+}
+
+const SWIPE_THRESHOLD = 100; // pixels
+
+const SwipeableBallotItem: React.FC<SwipeableBallotItemProps> = ({ onRemove, children }) => {
+  const startX = useRef<number | null>(null);
+  const [translateX, setTranslateX] = useState(0);
+
+  const handleStart = (clientX: number) => {
+    startX.current = clientX;
+  };
+
+  const handleMove = (clientX: number) => {
+    if (startX.current !== null) {
+      setTranslateX(clientX - startX.current);
+    }
+  };
+
+  const handleEnd = () => {
+    if (Math.abs(translateX) > SWIPE_THRESHOLD) {
+      onRemove();
+    }
+    setTranslateX(0);
+    startX.current = null;
+  };
+
+  const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    handleStart(e.clientX);
+    const onMove = (ev: MouseEvent) => handleMove(ev.clientX);
+    const onUp = () => {
+      handleEnd();
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
+  const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => handleStart(e.touches[0].clientX);
+  const onTouchMove = (e: React.TouchEvent<HTMLDivElement>) => handleMove(e.touches[0].clientX);
+  const onTouchEnd = () => handleEnd();
+
+  return (
+    <div
+      className="relative overflow-hidden"
+      onMouseDown={onMouseDown}
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+      style={{ touchAction: 'pan-y' }}
+    >
+      <div className="absolute inset-0 flex items-center justify-end pr-4 pointer-events-none">
+        <TrashIcon className="h-6 w-6 text-red-600" />
+      </div>
+      <div
+        className="transition-transform"
+        style={{ transform: `translateX(${translateX}px)` }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default SwipeableBallotItem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@heroicons/react": "^2.1.0",
         "firebase": "^11.8.1",
         "react": "^18.2.0",
+        "react-confetti": "^6.4.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.24.0"
       },
@@ -2100,6 +2101,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -2287,6 +2303,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
+      "license": "BSD"
     },
     "node_modules/typescript": {
       "version": "5.7.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@heroicons/react": "^2.1.0",
     "firebase": "^11.8.1",
     "react": "^18.2.0",
+    "react-confetti": "^6.4.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.24.0"
   },


### PR DESCRIPTION
## Summary
- add `SwipeableBallotItem` component for swipe-to-remove UI
- list candidate selections with the new swipe wrapper
- detect when all races have selections and fire one-time confetti
- include `react-confetti` dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684245f4b5488324bd7f953d8a82671e